### PR TITLE
[ChunkCodecCore] BREAKING Add requirement that `encode_bound` is monotonically increasing

### DIFF
--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -94,16 +94,22 @@ function codec end
     decoded_size_range(e)::StepRange{Int64, Int64}
 
 Return the range of allowed `src` sizes for encoding.
-[`encode_bound`](@ref) must not overflow for any `src_size` in this range.
+
+[`encode_bound`](@ref) on any value in the returned range must be in
+`0:typemax(Int64)-1`.
+
+See also [`encode_bound`](@ref)
 """
 function decoded_size_range end
 
 """
     encode_bound(e, src_size::Int64)::Int64
 
-Return the size of `dst` required to ensure [`try_encode!`](@ref) succeeds regardless of `src`'s content.
+Return the size of `dst` required to ensure [`try_encode!`](@ref)
+succeeds regardless of `src`'s content if `src_size` is also in
+[`decoded_size_range(e)`](@ref) and there is enough memory.
 
-Precondition: `src_size` is in [`decoded_size_range(e)`](@ref)
+This function must not error and must be monotonically increasing over the domain of all `Int64`.
 """
 function encode_bound end
 

--- a/ChunkCodecCore/src/interface.jl
+++ b/ChunkCodecCore/src/interface.jl
@@ -109,7 +109,7 @@ Return the size of `dst` required to ensure [`try_encode!`](@ref)
 succeeds regardless of `src`'s content if `src_size` is also in
 [`decoded_size_range(e)`](@ref) and there is enough memory.
 
-This function must not error and must be monotonically increasing over the domain of all `Int64`.
+On the domain of `0:typemax(Int64)` this function must not error and must be monotonically increasing.
 """
 function encode_bound end
 

--- a/ChunkCodecLibBlosc/src/encode.jl
+++ b/ChunkCodecLibBlosc/src/encode.jl
@@ -64,7 +64,9 @@ end
 # TODO update this when segfault is fixed upstream.
 decoded_size_range(e::BloscEncodeOptions) = Int64(0):Int64(e.typesize):Int64(2)^30
 
-encode_bound(::BloscEncodeOptions, src_size::Int64)::Int64 = Base.Checked.checked_add(src_size, BLOSC_MAX_OVERHEAD)
+function encode_bound(::BloscEncodeOptions, src_size::Int64)::Int64
+    clamp(widen(src_size) + widen(BLOSC_MAX_OVERHEAD), Int64)
+end
 
 function try_encode!(e::BloscEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
     check_contiguous(dst)

--- a/ChunkCodecLibBzip2/src/encode.jl
+++ b/ChunkCodecLibBzip2/src/encode.jl
@@ -28,14 +28,16 @@ end
 
 function decoded_size_range(::BZ2EncodeOptions)
     # prevent overflow of encode_bound
-    Int64(0):Int64(1):Int64(0x7e07_e07e_07e0_7bb8)
+    Int64(0):Int64(1):Int64(0x7e07_e07e_07e0_7bb7)
 end
 
 # According to the docs https://sourceware.org/bzip2/manual/manual.html:
 # "To guarantee that the compressed data will fit in its buffer,
 # allocate an output buffer of size 1% larger than the uncompressed data,
 # plus six hundred extra bytes."
-encode_bound(::BZ2EncodeOptions, src_size::Int64)::Int64 = Base.Checked.checked_add(src_size, src_size>>6 + Int64(601))
+function encode_bound(::BZ2EncodeOptions, src_size::Int64)::Int64
+    clamp(widen(src_size) + widen(src_size>>6 + Int64(601)), Int64)
+end
 
 function try_encode!(e::BZ2EncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
     check_contiguous(dst)

--- a/ChunkCodecLibBzip2/test/runtests.jl
+++ b/ChunkCodecLibBzip2/test/runtests.jl
@@ -15,7 +15,7 @@ Aqua.test_all(ChunkCodecLibBzip2)
 Random.seed!(1234)
 @testset "encode_bound" begin
     local a = last(decoded_size_range(BZ2EncodeOptions()))
-    @test encode_bound(BZ2EncodeOptions(), a) == typemax(Int64)
+    @test encode_bound(BZ2EncodeOptions(), a) == typemax(Int64) - 1
 end
 @testset "default" begin
     test_codec(BZ2Codec(), BZ2EncodeOptions(), BZ2DecodeOptions(); trials=50)

--- a/ChunkCodecLibLz4/src/encode.jl
+++ b/ChunkCodecLibLz4/src/encode.jl
@@ -138,9 +138,7 @@ end
 decoded_size_range(::LZ4BlockEncodeOptions) = Int64(0):Int64(1):LZ4_MAX_INPUT_SIZE
 
 function encode_bound(e::LZ4BlockEncodeOptions, src_size::Int64)::Int64
-    if src_size < 0
-        Int64(-1)
-    elseif src_size > last(decoded_size_range(e))
+    if src_size > last(decoded_size_range(e))
         typemax(Int64)
     else
         # from LZ4_COMPRESSBOUND in lz4.h

--- a/ChunkCodecLibLz4/src/encode.jl
+++ b/ChunkCodecLibLz4/src/encode.jl
@@ -80,7 +80,13 @@ function decoded_size_range(::LZ4FrameEncodeOptions)
 end
 
 function encode_bound(e::LZ4FrameEncodeOptions, src_size::Int64)::Int64
-    LZ4F_compressFrameBound(Csize_t(src_size), _preferences(e))
+    if src_size < 0
+        Int64(-1)
+    elseif src_size > last(decoded_size_range(e))
+        typemax(Int64)
+    else
+        LZ4F_compressFrameBound(Csize_t(src_size), _preferences(e))
+    end
 end
 
 function try_encode!(e::LZ4FrameEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
@@ -131,12 +137,15 @@ end
 
 decoded_size_range(::LZ4BlockEncodeOptions) = Int64(0):Int64(1):LZ4_MAX_INPUT_SIZE
 
-function encode_bound(::LZ4BlockEncodeOptions, src_size::Int64)::Int64
-    # from LZ4_COMPRESSBOUND in lz4.h
-    if src_size > LZ4_MAX_INPUT_SIZE
-        throw(OverflowError("$(src_size) must be at most $(LZ4_MAX_INPUT_SIZE)"))
+function encode_bound(e::LZ4BlockEncodeOptions, src_size::Int64)::Int64
+    if src_size < 0
+        Int64(-1)
+    elseif src_size > last(decoded_size_range(e))
+        typemax(Int64)
+    else
+        # from LZ4_COMPRESSBOUND in lz4.h
+        src_size + src_size÷Int64(255) + Int64(16)
     end
-    src_size + src_size÷Int64(255) + Int64(16)
 end
 
 function try_encode!(e::LZ4BlockEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
@@ -205,7 +214,7 @@ end
 decoded_size_range(e::LZ4ZarrEncodeOptions) = Int64(0):Int64(1):min(last(decoded_size_range(e.block_options)), Int64(typemax(Int32)))
 
 function encode_bound(e::LZ4ZarrEncodeOptions, src_size::Int64)::Int64
-    Base.Checked.checked_add(encode_bound(e.block_options, src_size), Int64(4))
+    clamp(widen(encode_bound(e.block_options, src_size)) + widen(Int64(4)), Int64)
 end
 
 function try_encode!(e::LZ4ZarrEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}

--- a/ChunkCodecLibZlib/src/encode.jl
+++ b/ChunkCodecLibZlib/src/encode.jl
@@ -92,9 +92,10 @@ is_thread_safe(::_AllEncodeOptions) = true
 # If alternate settings are used this must be modified.
 function encode_bound(e::_AllEncodeOptions, src_size::Int64)::Int64
     wraplen = _wraplen(e)
-    Base.Checked.checked_add(
-        src_size,
-        src_size>>12 + src_size>>14 + src_size>>25 + Int64(7) + wraplen
+    clamp(
+        widen(src_size) +
+        widen(src_size>>12 + src_size>>14 + src_size>>25 + Int64(7) + wraplen),
+        Int64,
     )
 end
 _wraplen(::ZlibEncodeOptions)    = Int64(6)
@@ -103,9 +104,9 @@ _wraplen(::GzipEncodeOptions)    = Int64(18)
 
 # max to prevent overflows in encode_bound
 # From ChunkCodecTests.find_max_decoded_size(::EncodeOptions)
-max_decoded_size(::ZlibEncodeOptions)::Int64 = 0x7ff60087fa602c73
-max_decoded_size(::DeflateEncodeOptions)::Int64 = 0x7ff60087fa602c79
-max_decoded_size(::GzipEncodeOptions)::Int64 = 0x7ff60087fa602c67
+max_decoded_size(::ZlibEncodeOptions)::Int64 = 0x7ff60087fa602c72
+max_decoded_size(::DeflateEncodeOptions)::Int64 = 0x7ff60087fa602c78
+max_decoded_size(::GzipEncodeOptions)::Int64 = 0x7ff60087fa602c66
 
 decoded_size_range(e::_AllEncodeOptions) = Int64(0):Int64(1):max_decoded_size(e)
 

--- a/ChunkCodecLibZlib/test/runtests.jl
+++ b/ChunkCodecLibZlib/test/runtests.jl
@@ -41,7 +41,7 @@ tests = [
 @testset "tests for $(codec)" for (codec, encode_opt, decode_opt) in tests
     @testset "encode_bound" begin
         local a = last(decoded_size_range(encode_opt()))
-        @test encode_bound(encode_opt(), a) == typemax(Int64)
+        @test encode_bound(encode_opt(), a) == typemax(Int64) - 1
     end
     @testset "default" begin
         test_codec(codec(), encode_opt(), decode_opt(); trials=50)

--- a/ChunkCodecLibZstd/src/encode.jl
+++ b/ChunkCodecLibZstd/src/encode.jl
@@ -40,10 +40,13 @@ function decoded_size_range(::ZstdEncodeOptions)
     # prevent overflow of encode_bound
     # like ZSTD_MAX_INPUT_SIZE for Int64
     # From ChunkCodecTests.find_max_decoded_size(ZstdEncodeOptions())
-    Int64(0):Int64(1):Int64(0x7F807F807F807F80)
+    Int64(0):Int64(1):Int64(0x7F807F807F807F7F)
 end
 
 function encode_bound(::ZstdEncodeOptions, src_size::Int64)::Int64
+    if src_size < 0
+        return Int64(-1)
+    end
     # ZSTD_COMPRESSBOUND ported to Julia
     # This also works when streaming
     # assuming no extra flushes
@@ -58,10 +61,7 @@ function encode_bound(::ZstdEncodeOptions, src_size::Int64)::Int64
     else 
         Int64(0)
     end::Int64
-    Base.Checked.checked_add(
-        src_size,
-        src_size>>8 + margin,
-    )
+    return clamp(widen(src_size) + widen(src_size>>8 + margin), Int64)
 end
 
 function try_encode!(e::ZstdEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}

--- a/ChunkCodecLibZstd/src/encode.jl
+++ b/ChunkCodecLibZstd/src/encode.jl
@@ -44,9 +44,6 @@ function decoded_size_range(::ZstdEncodeOptions)
 end
 
 function encode_bound(::ZstdEncodeOptions, src_size::Int64)::Int64
-    if src_size < 0
-        return Int64(-1)
-    end
     # ZSTD_COMPRESSBOUND ported to Julia
     # This also works when streaming
     # assuming no extra flushes
@@ -61,7 +58,7 @@ function encode_bound(::ZstdEncodeOptions, src_size::Int64)::Int64
     else 
         Int64(0)
     end::Int64
-    return clamp(widen(src_size) + widen(src_size>>8 + margin), Int64)
+    clamp(widen(src_size) + widen(src_size>>8 + margin), Int64)
 end
 
 function try_encode!(e::ZstdEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}

--- a/ChunkCodecLibZstd/test/runtests.jl
+++ b/ChunkCodecLibZstd/test/runtests.jl
@@ -18,7 +18,7 @@ Random.seed!(1234)
     @test encode_bound(ZstdEncodeOptions(), a) == typemax(Int64) - 1
     # zstd has adds a margin to encode bound for sizes less than 128 KB
     # Ensure this doesn't break monotonicity
-    for i in 0:(Int64(128)<<10 + 100)
+    for i in 1:(Int64(128)<<10 + 100)
         @test encode_bound(ZstdEncodeOptions(), i) ≥ encode_bound(ZstdEncodeOptions(), i-1)
     end
 end

--- a/ChunkCodecLibZstd/test/runtests.jl
+++ b/ChunkCodecLibZstd/test/runtests.jl
@@ -15,7 +15,12 @@ Aqua.test_all(ChunkCodecLibZstd)
 Random.seed!(1234)
 @testset "encode_bound" begin
     local a = last(decoded_size_range(ZstdEncodeOptions()))
-    @test encode_bound(ZstdEncodeOptions(), a) == typemax(Int64)
+    @test encode_bound(ZstdEncodeOptions(), a) == typemax(Int64) - 1
+    # zstd has adds a margin to encode bound for sizes less than 128 KB
+    # Ensure this doesn't break monotonicity
+    for i in 0:(Int64(128)<<10 + 100)
+        @test encode_bound(ZstdEncodeOptions(), i) ≥ encode_bound(ZstdEncodeOptions(), i-1)
+    end
 end
 @testset "default" begin
     test_codec(ZstdCodec(), ZstdEncodeOptions(), ZstdDecodeOptions(); trials=100)

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -50,9 +50,8 @@ function test_encoder_decoder(e, d; trials=100)
     @test step(srange) > 0
     @test first(srange) ≥ 0
     @test last(srange) != typemax(Int64) # avoid length overflow
-    # typemax(Int64) is reserved as a sentinel 
+    # typemax(Int64) is reserved as a sentinel
     @test encode_bound(e, last(srange)) < typemax(Int64)
-    @test encode_bound(e, typemin(Int64)) ≤ encode_bound(e, Int64(0))
     @test encode_bound(e, last(srange)) < encode_bound(e, typemax(Int64))
 
     for s in [first(srange):step(srange):min(last(srange), 1000); rand(srange, 10000); last(srange)]

--- a/ChunkCodecTests/src/ChunkCodecTests.jl
+++ b/ChunkCodecTests/src/ChunkCodecTests.jl
@@ -50,6 +50,10 @@ function test_encoder_decoder(e, d; trials=100)
     @test step(srange) > 0
     @test first(srange) ≥ 0
     @test last(srange) != typemax(Int64) # avoid length overflow
+    # typemax(Int64) is reserved as a sentinel 
+    @test encode_bound(e, last(srange)) < typemax(Int64)
+    @test encode_bound(e, typemin(Int64)) ≤ encode_bound(e, Int64(0))
+    @test encode_bound(e, last(srange)) < encode_bound(e, typemax(Int64))
 
     for s in [first(srange):step(srange):min(last(srange), 1000); rand(srange, 10000); last(srange)]
         @test encode_bound(e, s) isa Int64


### PR DESCRIPTION
If `encode_bound` is monotonically increasing it can be quickly inverted using binary search. This is useful when assembling encoders in a pipeline.