### PR TITLE
[Core] BREAKING Replace `codec` function with a `.codec` property

### DIFF
--- a/ChunkCodecCore/CHANGELOG.md
+++ b/ChunkCodecCore/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### BREAKING the `codec` function is replaced with a `.codec` property [#11](https://github.com/nhz2/ChunkCodecs.jl/pull/11)
+
 ## [v0.3.0](https://github.com/nhz2/ChunkCodecs.jl/tree/ChunkCodecCore-v0.3.0) - 2025-01-03
 
 ### BREAKING `encode_bound` is required to be monotonically increasing [#7](https://github.com/nhz2/ChunkCodecs.jl/pull/7)

--- a/ChunkCodecCore/src/ChunkCodecCore.jl
+++ b/ChunkCodecCore/src/ChunkCodecCore.jl
@@ -1,6 +1,6 @@
 module ChunkCodecCore
 
-export decode, encode, codec
+export decode, encode
 
 public Codec
 public EncodeOptions

--- a/ChunkCodecCore/src/noop.jl
+++ b/ChunkCodecCore/src/noop.jl
@@ -4,7 +4,7 @@
     struct NoopCodec <: Codec
     NoopCodec()
 
-This codec copies the input.
+Copies the input.
 
 See also [`NoopEncodeOptions`](@ref) and [`NoopDecodeOptions`](@ref)
 """
@@ -14,18 +14,23 @@ decode_options(::NoopCodec) = NoopDecodeOptions() # default decode options
 
 """
     struct NoopEncodeOptions <: EncodeOptions
-    NoopEncodeOptions(::NoopCodec=NoopCodec(); kwargs...)
+    NoopEncodeOptions(; kwargs...)
 
 Copies the input.
+
+# Keyword Arguments
+
+- `codec::NoopCodec=NoopCodec()`
 """
 struct NoopEncodeOptions <: EncodeOptions
-    function NoopEncodeOptions(::NoopCodec=NoopCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::NoopCodec
 end
-codec(::NoopEncodeOptions) = NoopCodec()
+function NoopEncodeOptions(;
+        codec::NoopCodec=NoopCodec(),
+        kwargs...
+    )
+    NoopEncodeOptions(codec)
+end
 
 is_thread_safe(::NoopEncodeOptions) = true
 
@@ -47,18 +52,23 @@ end
 
 """
     struct NoopDecodeOptions <: DecodeOptions
-    NoopDecodeOptions(::NoopCodec=NoopCodec(); kwargs...)
+    NoopDecodeOptions(; kwargs...)
 
 Copies the input.
+
+# Keyword Arguments
+
+- `codec::NoopCodec=NoopCodec()`
 """
 struct NoopDecodeOptions <: DecodeOptions
-    function NoopDecodeOptions(::NoopCodec=NoopCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::NoopCodec
 end
-codec(::NoopDecodeOptions) = NoopCodec()
+function NoopDecodeOptions(;
+        codec::NoopCodec=NoopCodec(),
+        kwargs...
+    )
+    NoopDecodeOptions(codec)
+end
 
 is_thread_safe(::NoopDecodeOptions) = true
 

--- a/ChunkCodecCore/src/shuffle.jl
+++ b/ChunkCodecCore/src/shuffle.jl
@@ -44,7 +44,7 @@ struct ShuffleCodec <: Codec
     end
 end
 
-decode_options(x::ShuffleCodec) = ShuffleDecodeOptions(x) # default decode options
+decode_options(x::ShuffleCodec) = ShuffleDecodeOptions(;codec=x) # default decode options
 
 # Allow ShuffleCodec to be used as an encoder
 decoded_size_range(::ShuffleCodec) = Int64(0):Int64(1):typemax(Int64)-Int64(1)
@@ -57,7 +57,7 @@ function try_encode!(e::ShuffleCodec, dst::AbstractVector{UInt8}, src::AbstractV
     element_size = e.element_size
     check_in_range(decoded_size_range(e); src_size)
     if dst_size < src_size
-        return nothing
+        nothing
     else
         if src_size>>1 < element_size || element_size == 1
             copyto!(dst, src)
@@ -79,21 +79,23 @@ end
 
 """
     struct ShuffleEncodeOptions <: EncodeOptions
-    ShuffleEncodeOptions(codec::ShuffleCodec; kwargs...)
+    ShuffleEncodeOptions(; kwargs...)
 
 Byte shuffle encoding.
 
-See also [`ShuffleCodec`](@ref)
+# Keyword Arguments
+
+- `codec::ShuffleCodec`
 """
 struct ShuffleEncodeOptions <: EncodeOptions
     codec::ShuffleCodec
-    function ShuffleEncodeOptions(codec::ShuffleCodec;
-            kwargs...
-        )
-        new(codec)
-    end
 end
-codec(x::ShuffleEncodeOptions) = x.codec
+function ShuffleEncodeOptions(;
+        codec::ShuffleCodec,
+        kwargs...
+    )
+    ShuffleEncodeOptions(codec)
+end
 
 is_thread_safe(::ShuffleEncodeOptions) = true
 
@@ -107,21 +109,23 @@ end
 
 """
     struct ShuffleDecodeOptions <: DecodeOptions
-    ShuffleDecodeOptions(codec::ShuffleCodec; kwargs...)
+    ShuffleDecodeOptions(; kwargs...)
 
 Byte shuffle decoding.
 
-See also [`ShuffleCodec`](@ref)
+# Keyword Arguments
+
+- `codec::ShuffleCodec`
 """
 struct ShuffleDecodeOptions <: DecodeOptions
     codec::ShuffleCodec
-    function ShuffleDecodeOptions(codec::ShuffleCodec;
-            kwargs...
-        )
-        new(codec)
-    end
 end
-codec(x::ShuffleDecodeOptions) = x.codec
+function ShuffleDecodeOptions(;
+        codec::ShuffleCodec,
+        kwargs...
+    )
+    ShuffleDecodeOptions(codec)
+end
 
 is_thread_safe(::ShuffleDecodeOptions) = true
 

--- a/ChunkCodecCore/src/types.jl
+++ b/ChunkCodecCore/src/types.jl
@@ -3,7 +3,7 @@
 
 Required information to decode encoded data.
 
-Fields are public.
+Properties are public for reading.
 
 Required methods for a type `T <: Codec` to implement:
 - `decode_options(::T)::DecodeOptions`
@@ -18,8 +18,10 @@ abstract type Codec end
 
 Options for encoding data.
 
-Fields are public.
-A `.codec` field that is a `Codec` is required.
+Properties are public for reading.
+All `EncodeOptions` have a keyword argument constructor
+that accept all properties as arguments.
+All `EncodeOptions` have a `codec::Codec` property.
 
 Required methods for a type `T <: EncodeOptions` to implement:
 - `decoded_size_range(::T)::StepRange{Int64, Int64}`
@@ -37,8 +39,10 @@ abstract type EncodeOptions end
 
 Options for decoding data.
 
-Fields are public.
-A `.codec` field that is a `Codec` is required.
+Properties are public for reading.
+All `DecodeOptions` have a keyword argument constructor
+that accept all properties as arguments.
+All `DecodeOptions` have a `codec::Codec` property.
 
 Required methods for a type `T <: DecodeOptions` to implement:
 - `try_find_decoded_size(::T, src::AbstractVector{UInt8})::Union{Nothing, Int64}`

--- a/ChunkCodecCore/src/types.jl
+++ b/ChunkCodecCore/src/types.jl
@@ -3,6 +3,8 @@
 
 Required information to decode encoded data.
 
+Fields are public.
+
 Required methods for a type `T <: Codec` to implement:
 - `decode_options(::T)::DecodeOptions`
 
@@ -16,8 +18,10 @@ abstract type Codec end
 
 Options for encoding data.
 
+Fields are public.
+A `.codec` field that is a `Codec` is required.
+
 Required methods for a type `T <: EncodeOptions` to implement:
-- `codec(::T)::Codec`
 - `decoded_size_range(::T)::StepRange{Int64, Int64}`
 - `encode_bound(::T, src_size::Int64)::Int64`
 - `try_encode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}`
@@ -33,8 +37,10 @@ abstract type EncodeOptions end
 
 Options for decoding data.
 
+Fields are public.
+A `.codec` field that is a `Codec` is required.
+
 Required methods for a type `T <: DecodeOptions` to implement:
-- `codec(::T)::Codec`
 - `try_find_decoded_size(::T, src::AbstractVector{UInt8})::Union{Nothing, Int64}`
 - `try_decode!(::T, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}`
 

--- a/ChunkCodecCore/test/runtests.jl
+++ b/ChunkCodecCore/test/runtests.jl
@@ -54,13 +54,14 @@ end
 
 # version of NoopDecodeOptions that returns unknown try_find_decoded_size
 struct TestDecodeOptions <: ChunkCodecCore.DecodeOptions
-    function TestDecodeOptions(::NoopCodec=NoopCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::NoopCodec
 end
-ChunkCodecCore.codec(::TestDecodeOptions) = NoopCodec()
+function TestDecodeOptions(;
+        codec::NoopCodec=NoopCodec(),
+        kwargs...
+    )
+    TestDecodeOptions(codec)
+end
 ChunkCodecCore.try_find_decoded_size(::TestDecodeOptions, src::AbstractVector{UInt8}) = nothing
 function ChunkCodecCore.try_decode!(::TestDecodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
     dst_size::Int64 = length(dst)

--- a/ChunkCodecs/src/ChunkCodecs.jl
+++ b/ChunkCodecs/src/ChunkCodecs.jl
@@ -1,8 +1,8 @@
 module ChunkCodecs
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 codec_packages = [
     :ChunkCodecLibBlosc,

--- a/LibBlosc/src/ChunkCodecLibBlosc.jl
+++ b/LibBlosc/src/ChunkCodecLibBlosc.jl
@@ -10,7 +10,6 @@ using ChunkCodecCore:
     check_contiguous,
     DecodingError
 import ChunkCodecCore:
-    codec,
     decode_options,
     try_decode!,
     try_encode!,
@@ -26,8 +25,8 @@ export BloscCodec,
 public is_compressor_valid
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 include("libblosc.jl")
 

--- a/LibBlosc/src/decode.jl
+++ b/LibBlosc/src/decode.jl
@@ -13,29 +13,30 @@ function Base.showerror(io::IO, err::BloscDecodingError)
     nothing
 end
 
-struct BloscDecodeOptions <: DecodeOptions
-    numinternalthreads::Cint
-end
-codec(::BloscDecodeOptions) = BloscCodec()
-
 """
     struct BloscDecodeOptions <: DecodeOptions
-    BloscDecodeOptions(::BloscCodec=BloscCodec(); kwargs...)
+    BloscDecodeOptions(; kwargs...)
 
 Blosc decompression using c-blosc library: https://github.com/Blosc/c-blosc
 
 # Keyword Arguments
 
+- `codec::BloscCodec=BloscCodec()`
 - `numinternalthreads::Integer=1`: The number of threads to use internally,
 Must be in `1:$(BLOSC_MAX_THREADS)`.
 
 """
-function BloscDecodeOptions(::BloscCodec=BloscCodec();
+struct BloscDecodeOptions <: DecodeOptions
+    codec::BloscCodec
+    numinternalthreads::Cint
+end
+function BloscDecodeOptions(;
+        codec::BloscCodec=BloscCodec(),
         numinternalthreads::Integer=1,
         kwargs...
     )
     check_in_range(1:BLOSC_MAX_THREADS; numinternalthreads)
-    BloscDecodeOptions(numinternalthreads)
+    BloscDecodeOptions(codec, numinternalthreads)
 end
 
 function try_find_decoded_size(::BloscDecodeOptions, src::AbstractVector{UInt8})::Int64

--- a/LibBlosc/src/encode.jl
+++ b/LibBlosc/src/encode.jl
@@ -1,11 +1,12 @@
 """
     struct BloscEncodeOptions <: EncodeOptions
-    BloscEncodeOptions(::BloscCodec=BloscCodec(); kwargs...)
+    BloscEncodeOptions(; kwargs...)
 
 Blosc compression using c-blosc library: https://github.com/Blosc/c-blosc
 
 # Keyword Arguments
 
+- `codec::BloscCodec=BloscCodec()`
 - `clevel::Integer=5`: The compression level, between 0 (no compression) and 9 (maximum compression)
 - `doshuffle::Integer=1`: Whether to use the shuffle filter.
 0 means not applying it, 1 means applying it at a byte level,
@@ -23,6 +24,7 @@ automatic blocksize will be used.
 Must be in `1:$(BLOSC_MAX_THREADS)`.
 """
 struct BloscEncodeOptions <: EncodeOptions
+    codec::BloscCodec
     clevel::Cint
     doshuffle::Cint
     typesize::Csize_t
@@ -30,9 +32,8 @@ struct BloscEncodeOptions <: EncodeOptions
     blocksize::Csize_t
     numinternalthreads::Cint
 end
-codec(::BloscEncodeOptions) = BloscCodec()
-
-function BloscEncodeOptions(::BloscCodec=BloscCodec();
+function BloscEncodeOptions(;
+        codec::BloscCodec=BloscCodec(),
         clevel::Integer=5,
         doshuffle::Integer=1,
         typesize::Integer=1,
@@ -52,6 +53,7 @@ function BloscEncodeOptions(::BloscCodec=BloscCodec();
     check_in_range(typemin(Csize_t):typemax(Csize_t); blocksize)
     check_in_range(1:BLOSC_MAX_THREADS; numinternalthreads)
     BloscEncodeOptions(
+        codec,
         clevel,
         doshuffle,
         _typesize,

--- a/LibBzip2/src/ChunkCodecLibBzip2.jl
+++ b/LibBzip2/src/ChunkCodecLibBzip2.jl
@@ -10,7 +10,6 @@ using ChunkCodecCore:
     check_contiguous,
     DecodingError
 import ChunkCodecCore:
-    codec,
     decode_options,
     can_concatenate,
     try_decode!,
@@ -27,8 +26,8 @@ export BZ2Codec,
     BZ2DecodingError
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 
 include("libbzip2.jl")

--- a/LibBzip2/src/decode.jl
+++ b/LibBzip2/src/decode.jl
@@ -24,18 +24,23 @@ end
 
 """
     struct BZ2DecodeOptions <: DecodeOptions
-    BZ2DecodeOptions(::BloscCodec=BloscCodec(); kwargs...)
+    BZ2DecodeOptions(; kwargs...)
 
 bzip2 decompression using libbzip2: https://sourceware.org/bzip2/
+
+# Keyword Arguments
+
+- `codec::BZ2Codec=BZ2Codec()`
 """
 struct BZ2DecodeOptions <: DecodeOptions
-    function BZ2DecodeOptions(::BZ2Codec=BZ2Codec();
-            kwargs...
-        )
-        new()
-    end
+    codec::BZ2Codec
 end
-codec(::BZ2DecodeOptions) = BZ2Codec()
+function BZ2DecodeOptions(;
+        codec::BZ2Codec=BZ2Codec(),
+        kwargs...
+    )
+    BZ2DecodeOptions(codec)
+end
 is_thread_safe(::BZ2DecodeOptions) = true
 
 function try_find_decoded_size(::BZ2DecodeOptions, src::AbstractVector{UInt8})::Nothing

--- a/LibBzip2/src/encode.jl
+++ b/LibBzip2/src/encode.jl
@@ -1,27 +1,30 @@
 """
     struct BZ2EncodeOptions <: EncodeOptions
-    BZ2EncodeOptions(::BZ2Codec=BZ2Codec(); kwargs...)
+    BZ2EncodeOptions(; kwargs...)
 
 bzip2 compression using libbzip2: https://sourceware.org/bzip2/
 
 # Keyword Arguments
 
+-`codec::BZ2Codec=BZ2Codec()`
 - `blockSize100k::Integer=9`: Specifies the block size to be used for compression.
 It should be a value between 1 and 9 inclusive, and the actual block size used
 is 100000 x this figure. The default 9 gives the best compression but takes most memory.
 """
 struct BZ2EncodeOptions <: EncodeOptions
+    codec::BZ2Codec
     blockSize100k::Cint
 end
-codec(::BZ2EncodeOptions) = BZ2Codec()
 is_thread_safe(::BZ2EncodeOptions) = true
 
-function BZ2EncodeOptions(::BZ2Codec=BZ2Codec();
+function BZ2EncodeOptions(;
+        codec::BZ2Codec=BZ2Codec(),
         blockSize100k::Integer=9,
         kwargs...
     )
     check_in_range(1:9; blockSize100k)
     BZ2EncodeOptions(
+        codec,
         blockSize100k,
     )
 end

--- a/LibLz4/src/ChunkCodecLibLz4.jl
+++ b/LibLz4/src/ChunkCodecLibLz4.jl
@@ -10,7 +10,6 @@ using ChunkCodecCore:
     check_in_range,
     DecodingError
 import ChunkCodecCore:
-    codec,
     decode_options,
     can_concatenate,
     try_decode!,
@@ -39,8 +38,8 @@ export LZ4FrameCodec,
 public LZ4F_MAX_CLEVEL
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 
 include("liblz4.jl")

--- a/LibLz4/src/decode.jl
+++ b/LibLz4/src/decode.jl
@@ -15,18 +15,24 @@ end
 
 """
     struct LZ4FrameDecodeOptions <: DecodeOptions
-    LZ4FrameDecodeOptions(::LZ4FrameCodec=LZ4FrameCodec(); kwargs...)
+    LZ4FrameDecodeOptions(; kwargs...)
 
 lz4 frame decompression using liblz4: https://lz4.org/
+
+# Keyword Arguments
+
+- `codec::LZ4FrameCodec=LZ4FrameCodec()`
 """
 struct LZ4FrameDecodeOptions <: DecodeOptions
-    function LZ4FrameDecodeOptions(::LZ4FrameCodec=LZ4FrameCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::LZ4FrameCodec
 end
-codec(::LZ4FrameDecodeOptions) = LZ4FrameCodec()
+function LZ4FrameDecodeOptions(;
+        codec::LZ4FrameCodec=LZ4FrameCodec(),
+        kwargs...
+    )
+    LZ4FrameDecodeOptions(codec)
+end
+
 is_thread_safe(::LZ4FrameDecodeOptions) = true
 
 function try_find_decoded_size(::LZ4FrameDecodeOptions, src::AbstractVector{UInt8})::Nothing
@@ -138,15 +144,20 @@ end
     LZ4BlockDecodeOptions(::LZ4BlockCodec=LZ4BlockCodec(); kwargs...)
 
 lz4 block decompression using liblz4: https://lz4.org/
+
+# Keyword Arguments
+
+- `codec::LZ4BlockCodec=LZ4BlockCodec()`
 """
 struct LZ4BlockDecodeOptions <: DecodeOptions
-    function LZ4BlockDecodeOptions(::LZ4BlockCodec=LZ4BlockCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::LZ4BlockCodec
 end
-codec(::LZ4BlockDecodeOptions) = LZ4BlockCodec()
+function LZ4BlockDecodeOptions(;
+        codec::LZ4BlockCodec=LZ4BlockCodec(),
+        kwargs...
+    )
+    LZ4BlockDecodeOptions(codec)
+end
 is_thread_safe(::LZ4BlockDecodeOptions) = true
 
 # There is no header or footer, so always return nothing
@@ -304,15 +315,21 @@ end
 lz4 numcodecs style compression using liblz4: https://lz4.org/
 
 This is the LZ4 Zarr format described in https://numcodecs.readthedocs.io/en/stable/compression/lz4.html
+
+# Keyword Arguments
+
+- `codec::LZ4ZarrCodec=LZ4ZarrCodec()`
 """
 struct LZ4ZarrDecodeOptions <: DecodeOptions
-    function LZ4ZarrDecodeOptions(::LZ4ZarrCodec=LZ4ZarrCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::LZ4ZarrCodec
 end
-codec(::LZ4ZarrDecodeOptions) = LZ4ZarrCodec()
+function LZ4ZarrDecodeOptions(;
+        codec::LZ4ZarrCodec=LZ4ZarrCodec(),
+        kwargs...
+    )
+    LZ4ZarrDecodeOptions(codec)
+end
+
 is_thread_safe(::LZ4ZarrDecodeOptions) = true
 
 # There is a 4 byte header with the decoded size as a 32 bit unsigned integer

--- a/LibLz4/src/encode.jl
+++ b/LibLz4/src/encode.jl
@@ -1,11 +1,12 @@
 """
     struct LZ4FrameEncodeOptions <: EncodeOptions
-    LZ4FrameEncodeOptions(::LZ4FrameCodec=LZ4FrameCodec(); kwargs...)
+    LZ4FrameEncodeOptions(; kwargs...)
 
 This is the LZ4 Frame (.lz4) format described in https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Frame_format.md
 
 # Keyword Arguments
 
+- `codec::LZ4FrameCodec=LZ4FrameCodec()`
 - `compressionLevel::Integer=0`: Compression level, 0: default (fast mode); values > `LZ4F_MAX_CLEVEL` count as `LZ4F_MAX_CLEVEL`; values < 0 trigger fast acceleration
 - `blockSizeID::Integer=0`: 0: default (max64KB), 4: max64KB, 5: max256KB, 6: max1MB, 7: max4MB;
 The larger the block size, the (slightly) better the compression ratio,
@@ -22,6 +23,7 @@ limitation in liblz4. Ref: https://github.com/lz4/lz4/issues/775
 - `favorDecSpeed::Bool=false`: if true, parser favors decompression speed vs compression ratio. Only works for high compressionLevel (>= LZ4HC_CLEVEL_OPT_MIN)
 """
 struct LZ4FrameEncodeOptions <: EncodeOptions
+    codec::LZ4FrameCodec
     compressionLevel::Cint
     blockSizeID::Cint
     blockMode::Bool
@@ -30,10 +32,8 @@ struct LZ4FrameEncodeOptions <: EncodeOptions
     blockChecksumFlag::Bool
     favorDecSpeed::Bool
 end
-codec(::LZ4FrameEncodeOptions) = LZ4FrameCodec()
-is_thread_safe(::LZ4FrameEncodeOptions) = true
-
-function LZ4FrameEncodeOptions(::LZ4FrameCodec=LZ4FrameCodec();
+function LZ4FrameEncodeOptions(;
+        codec::LZ4FrameCodec=LZ4FrameCodec(),
         compressionLevel::Integer=0,
         blockSizeID::Integer=0,
         blockMode::Bool=false,
@@ -45,8 +45,10 @@ function LZ4FrameEncodeOptions(::LZ4FrameCodec=LZ4FrameCodec();
     )
     blockSizeID ∈ (0, 4, 5, 6, 7) || throw(ArgumentError("blockSizeID: $(blockSizeID) must be in (0, 4, 5, 6, 7)"))
     _clamped_compression_level = clamp(compressionLevel, -(LZ4_ACCELERATION_MAX - 1), LZ4F_MAX_CLEVEL)
-    LZ4FrameEncodeOptions(_clamped_compression_level, blockSizeID, blockMode, contentChecksumFlag, contentSize, blockChecksumFlag, favorDecSpeed)
+    LZ4FrameEncodeOptions(codec, _clamped_compression_level, blockSizeID, blockMode, contentChecksumFlag, contentSize, blockChecksumFlag, favorDecSpeed)
 end
+
+is_thread_safe(::LZ4FrameEncodeOptions) = true
 
 function _preferences(e::LZ4FrameEncodeOptions)::LZ4F_preferences_t
     LZ4F_preferences_t(
@@ -109,7 +111,7 @@ end
 
 """
     struct LZ4BlockEncodeOptions <: EncodeOptions
-    LZ4BlockEncodeOptions(::LZ4BlockCodec=LZ4BlockCodec(); kwargs...)
+    LZ4BlockEncodeOptions(; kwargs...)
 
 This is the LZ4 Block format described in https://github.com/lz4/lz4/blob/v1.10.0/doc/lz4_Block_format.md
 
@@ -119,20 +121,22 @@ There is also a maximum decoded size of about 2 GB for this implementation.
 
 # Keyword Arguments
 
+- `codec::LZ4BlockCodec=LZ4BlockCodec()`
 - `compressionLevel::Integer=0`: Compression level, 0: default (fast mode); values > `LZ4F_MAX_CLEVEL` count as `LZ4F_MAX_CLEVEL`; values < 0 trigger fast acceleration
 """
 struct LZ4BlockEncodeOptions <: EncodeOptions
+    codec::LZ4BlockCodec
     compressionLevel::Cint
 end
-codec(::LZ4BlockEncodeOptions) = LZ4BlockCodec()
 is_thread_safe(::LZ4BlockEncodeOptions) = true
 
-function LZ4BlockEncodeOptions(::LZ4BlockCodec=LZ4BlockCodec();
+function LZ4BlockEncodeOptions(;
+        codec::LZ4BlockCodec=LZ4BlockCodec(),
         compressionLevel::Integer=0,
         kwargs...
     )
     _clamped_compression_level = clamp(compressionLevel, -(LZ4_ACCELERATION_MAX - 1), LZ4F_MAX_CLEVEL)
-    LZ4BlockEncodeOptions(_clamped_compression_level)
+    LZ4BlockEncodeOptions(codec, _clamped_compression_level)
 end
 
 decoded_size_range(::LZ4BlockEncodeOptions) = Int64(0):Int64(1):LZ4_MAX_INPUT_SIZE
@@ -186,7 +190,7 @@ end
 
 """
     struct LZ4ZarrEncodeOptions <: EncodeOptions
-    LZ4ZarrEncodeOptions(::LZ4ZarrCodec=LZ4ZarrCodec(); kwargs...)
+    LZ4ZarrEncodeOptions(; kwargs...)
 
 lz4 numcodecs style compression using liblz4: https://lz4.org/
 
@@ -194,25 +198,27 @@ This is the LZ4 Zarr format described in https://numcodecs.readthedocs.io/en/sta
 
 # Keyword Arguments
 
+- `codec::LZ4ZarrCodec=LZ4ZarrCodec()`
 - `compressionLevel::Integer=0`: Compression level, 0: default (fast mode); values > `LZ4F_MAX_CLEVEL` count as `LZ4F_MAX_CLEVEL`; values < 0 trigger fast acceleration
 """
 struct LZ4ZarrEncodeOptions <: EncodeOptions
-    block_options::LZ4BlockEncodeOptions
+    codec::LZ4ZarrCodec
+    compressionLevel::Cint
 end
-codec(::LZ4ZarrEncodeOptions) = LZ4ZarrCodec()
 is_thread_safe(::LZ4ZarrEncodeOptions) = true
 
-function LZ4ZarrEncodeOptions(::LZ4ZarrCodec=LZ4ZarrCodec();
+function LZ4ZarrEncodeOptions(;
+        codec::LZ4ZarrCodec=LZ4ZarrCodec(),
         compressionLevel::Integer=0,
         kwargs...
     )
-    LZ4ZarrEncodeOptions(LZ4BlockEncodeOptions(;compressionLevel))
+    LZ4ZarrEncodeOptions(codec, LZ4BlockEncodeOptions(;compressionLevel).compressionLevel)
 end
 
-decoded_size_range(e::LZ4ZarrEncodeOptions) = Int64(0):Int64(1):min(last(decoded_size_range(e.block_options)), Int64(typemax(Int32)))
+decoded_size_range(e::LZ4ZarrEncodeOptions) = Int64(0):Int64(1):min(LZ4_MAX_INPUT_SIZE, Int64(typemax(Int32)))
 
 function encode_bound(e::LZ4ZarrEncodeOptions, src_size::Int64)::Int64
-    clamp(widen(encode_bound(e.block_options, src_size)) + widen(Int64(4)), Int64)
+    clamp(widen(encode_bound(LZ4BlockEncodeOptions(), src_size)) + widen(Int64(4)), Int64)
 end
 
 function try_encode!(e::LZ4ZarrEncodeOptions, dst::AbstractVector{UInt8}, src::AbstractVector{UInt8}; kwargs...)::Union{Nothing, Int64}
@@ -226,7 +232,8 @@ function try_encode!(e::LZ4ZarrEncodeOptions, dst::AbstractVector{UInt8}, src::A
     for i in 0:3
         dst[begin+i] = src_size>>>(i*8) & 0xFF
     end
-    ret = try_encode!(e.block_options, @view(dst[begin+4:end]) , src)
+    block_options = LZ4BlockEncodeOptions(LZ4BlockCodec(), e.compressionLevel)
+    ret = try_encode!(block_options, @view(dst[begin+4:end]) , src)
     if isnothing(ret)
         return nothing
     else

--- a/LibZlib/src/ChunkCodecLibZlib.jl
+++ b/LibZlib/src/ChunkCodecLibZlib.jl
@@ -10,7 +10,6 @@ using ChunkCodecCore:
     check_in_range,
     DecodingError
 import ChunkCodecCore:
-    codec,
     decode_options,
     can_concatenate,
     try_decode!,
@@ -33,8 +32,8 @@ export ZlibCodec,
     LibzDecodingError
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 
 include("libz.jl")

--- a/LibZlib/src/decode.jl
+++ b/LibZlib/src/decode.jl
@@ -105,10 +105,10 @@ function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, sr
     end
     cconv_src = Base.cconvert(Ptr{UInt8}, src)
     # This outer loop is to decode a concatenation of multiple compressed streams.
-    # If `can_concatenate(codec(d))` is false, this outer loop doesn't rerun.
+    # If `can_concatenate(d.codec)` is false, this outer loop doesn't rerun.
     while true
         stream = ZStream()
-        inflateInit2(stream, _windowBits(codec(d)))
+        inflateInit2(stream, _windowBits(d.codec))
         try
             # This inner loop is needed because libz can work on at most 
             # 2^32 - 1 bytes at a time.
@@ -178,7 +178,7 @@ function try_resize_decode!(d::_AllDecodeOptions, dst::AbstractVector{UInt8}, sr
                             end
                             return real_dst_size
                         else
-                            if can_concatenate(codec(d))
+                            if can_concatenate(d.codec)
                                 # try and decompress next stream if the codec can_concatenate
                                 # there must be progress
                                 @assert stream.avail_in < start_avail_in || stream.avail_out < start_avail_out

--- a/LibZlib/src/decode.jl
+++ b/LibZlib/src/decode.jl
@@ -15,49 +15,70 @@ end
 
 """
     struct ZlibDecodeOptions <: DecodeOptions
-    ZlibDecodeOptions(::ZlibCodec=ZlibCodec(); kwargs...)
+    ZlibDecodeOptions(; kwargs...)
 
 zlib decompression using libzlib: https://www.zlib.net/
+
+This is the zlib format described in RFC 1950
+
+# Keyword Arguments
+
+- `codec::ZlibCodec=ZlibCodec()`
 """
 struct ZlibDecodeOptions <: DecodeOptions
-    function ZlibDecodeOptions(::ZlibCodec=ZlibCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::ZlibCodec
 end
-codec(::ZlibDecodeOptions) = ZlibCodec()
+function ZlibDecodeOptions(;
+        codec::ZlibCodec=ZlibCodec(),
+        kwargs...
+    )
+    ZlibDecodeOptions(codec)
+end
 
 """
     struct DeflateDecodeOptions <: DecodeOptions
-    DeflateDecodeOptions(::DeflateCodec=DeflateCodec(); kwargs...)
+    DeflateDecodeOptions(; kwargs...)
 
 deflate decompression using libzlib: https://www.zlib.net/
+
+This is the deflate format described in RFC 1951
+
+# Keyword Arguments
+
+- `codec::DeflateCodec=DeflateCodec()`
 """
 struct DeflateDecodeOptions <: DecodeOptions
-    function DeflateDecodeOptions(::DeflateCodec=DeflateCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::DeflateCodec
 end
-codec(::DeflateDecodeOptions) = DeflateCodec()
+function DeflateDecodeOptions(;
+        codec::DeflateCodec=DeflateCodec(),
+        kwargs...
+    )
+    DeflateDecodeOptions(codec)
+end
 
 
 """
     struct GzipDecodeOptions <: DecodeOptions
-    GzipDecodeOptions(::GzipCodec=GzipCodec(); kwargs...)
+    GzipDecodeOptions(; kwargs...)
 
 gzip decompression using libzlib: https://www.zlib.net/
+
+This is the gzip (.gz) format described in RFC 1952
+
+# Keyword Arguments
+
+- `codec::GzipCodec=GzipCodec()`
 """
 struct GzipDecodeOptions <: DecodeOptions
-    function GzipDecodeOptions(::GzipCodec=GzipCodec();
-            kwargs...
-        )
-        new()
-    end
+    codec::GzipCodec
 end
-codec(::GzipDecodeOptions) = GzipCodec()
+function GzipDecodeOptions(;
+        codec::GzipCodec=GzipCodec(),
+        kwargs...
+    )
+    GzipDecodeOptions(codec)
+end
 
 const _AllDecodeOptions = Union{ZlibDecodeOptions, DeflateDecodeOptions, GzipDecodeOptions}
 

--- a/LibZlib/test/runtests.jl
+++ b/LibZlib/test/runtests.jl
@@ -47,9 +47,10 @@ tests = [
         test_codec(codec(), encode_opt(), decode_opt(); trials=50)
     end
     @testset "level options" begin
-        @test_throws ArgumentError encode_opt(; level=-10)
-        @test_throws ArgumentError encode_opt(; level=10)
-        @test_throws ArgumentError encode_opt(; level=-2)
+        # level should get clamped to -1 to 9
+        @test encode_opt(; level=-10).level == -1
+        @test encode_opt(; level=10).level == 9
+        @test encode_opt(; level=-2).level == -1
         for i in -1:9
             test_codec(codec(), encode_opt(; level=i), decode_opt(); trials=5)
         end

--- a/LibZstd/src/ChunkCodecLibZstd.jl
+++ b/LibZstd/src/ChunkCodecLibZstd.jl
@@ -11,7 +11,6 @@ using ChunkCodecCore:
     DecodingError
 
 import ChunkCodecCore:
-    codec,
     can_concatenate,
     try_decode!,
     try_encode!,
@@ -35,8 +34,8 @@ public MIN_CLEVEL,
     ZSTD_cParam_getBounds
 
 # reexport ChunkCodecCore
-using ChunkCodecCore: ChunkCodecCore, encode, decode, codec
-export ChunkCodecCore, encode, decode, codec
+using ChunkCodecCore: ChunkCodecCore, encode, decode
+export ChunkCodecCore, encode, decode
 
 
 include("libzstd.jl")
@@ -54,7 +53,7 @@ decompressed size. Decoding will succeed even if the decompressed size is unknow
 Also like libzstd's simple API, decoding accepts concatenated frames 
 and will error if there is invalid data appended.
 
-[`ZlibEncodeOptions`](@ref) and [`ZlibDecodeOptions`](@ref)
+[`ZstdEncodeOptions`](@ref) and [`ZstdDecodeOptions`](@ref)
 can be used to set decoding and encoding options.
 """
 struct ZstdCodec <: Codec

--- a/LibZstd/src/decode.jl
+++ b/LibZstd/src/decode.jl
@@ -19,25 +19,28 @@ end
 
 """
     struct ZstdDecodeOptions <: DecodeOptions
-    ZstdDecodeOptions(::ZstdCodec=ZstdCodec(); kwargs...)
+    ZstdDecodeOptions(; kwargs...)
 
 # Keyword Arguments
 
+- `codec::ZstdCodec=ZstdCodec()`
 - `advanced_parameters::Vector{Pair{Cint, Cint}}=[]`:
 Warning, some parameters are experimental and may change in new versions of libzstd,
 so you may need to check `ZSTD_VERSION`. See comments in zstd.h.
 Additional parameters are set with `ZSTD_DCtx_setParameter`.
 """
 struct ZstdDecodeOptions <: DecodeOptions
+    codec::ZstdCodec
     advanced_parameters::Vector{Pair{Cint, Cint}}
 end
-function ZstdDecodeOptions(::ZstdCodec=ZstdCodec(); 
+function ZstdDecodeOptions(;
+        codec::ZstdCodec=ZstdCodec(),
         advanced_parameters::Vector{Pair{Cint, Cint}}=Pair{Cint, Cint}[],
         kwargs...
     )
-    ZstdDecodeOptions(advanced_parameters)
+    ZstdDecodeOptions(codec, advanced_parameters)
 end
-codec(::ZstdDecodeOptions) = ZstdCodec()
+
 is_thread_safe(::ZstdDecodeOptions) = true
 
 # find_decompressed_size is modified from CodecZstd.jl

--- a/LibZstd/src/encode.jl
+++ b/LibZstd/src/encode.jl
@@ -1,9 +1,10 @@
 """
     struct ZstdEncodeOptions <: EncodeOptions
-    ZstdEncodeOptions(::ZstdCodec=ZstdCodec(); kwargs...)
+    ZstdEncodeOptions(; kwargs...)
 
 # Keyword Arguments
 
+- `codec::ZstdCodec=ZstdCodec()`
 - `compressionLevel::Integer=0`: Compression level, regular levels are 1-22.
 Levels ≥ 20 should be used with caution, as they require more memory.
 0 is a special value for `DEFAULT_CLEVEL`.
@@ -19,21 +20,23 @@ are set after the compression level, and checksum options are set,
 so they can override those values.
 """
 struct ZstdEncodeOptions <: EncodeOptions
+    codec::ZstdCodec
     compressionLevel::Cint
     checksum::Bool
     advanced_parameters::Vector{Pair{Cint, Cint}}
 end
-codec(::ZstdEncodeOptions) = ZstdCodec()
+
 is_thread_safe(::ZstdEncodeOptions) = true
 
-function ZstdEncodeOptions(::ZstdCodec=ZstdCodec();
+function ZstdEncodeOptions(;
+        codec::ZstdCodec=ZstdCodec(),
         compressionLevel::Integer=0,
         checksum::Bool=false,
         advanced_parameters::Vector{Pair{Cint, Cint}}=Pair{Cint, Cint}[],
         kwargs...
     )
     _clamped_compression_level = clamp(compressionLevel, MIN_CLEVEL, MAX_CLEVEL)
-    ZstdEncodeOptions(_clamped_compression_level, checksum, advanced_parameters)
+    ZstdEncodeOptions(codec, _clamped_compression_level, checksum, advanced_parameters)
 end
 
 function decoded_size_range(::ZstdEncodeOptions)

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ true
 Most of the parameters in an `EncodeOptions` are not needed to be able to
 decode back to the original data.
 
-The `Codec` object returned by `codec` has the meta data required for decoding.
+The `Codec` object in the `codec` property has the meta data required for decoding.
 
 ```julia-repl
-julia> gz_codec = codec(e)
+julia> gz_codec = e.codec
 GzipCodec()
 
 julia> gz_codec isa ChunkCodecCore.Codec

--- a/test/imagecodecs-compat.jl
+++ b/test/imagecodecs-compat.jl
@@ -27,7 +27,7 @@ codecs = [
     for s in decoded_sizes
         im_enc(x) = pyconvert(Vector, im_enc_funct(x; im_options[2]...))
         im_dec(x) = pyconvert(Vector, im_dec_funct(x; out=zeros(UInt8, s), im_options[2]...))
-        jl_dec(x) = decode(codec(jl_options), x; size_hint=s)
+        jl_dec(x) = decode(jl_options.codec, x; size_hint=s)
         jl_enc(x) = encode(jl_options, x)
         local data = rand_test_data(s)
         has_encode, has_decode = if length(im_options) ≤ 2


### PR DESCRIPTION
This PR also marks the properties of `Codec`, `EncodeOptions`, and `DecodeOptions` as public for reading.

This should make it easier to save options to HDF5 or Zarr formats in external packages.