### PR TITLE
Make compatible with Julia 1.10 using Compat.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,6 +75,7 @@ jobs:
         # e.g. ['package1', 'package2'] if both package folders contains changes
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
         version:
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest

--- a/ChunkCodecCore/Project.toml
+++ b/ChunkCodecCore/Project.toml
@@ -3,5 +3,8 @@ uuid = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 authors = ["nhz2 <nhz2@cornell.edu>"]
 version = "0.4.0"
 
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+
 [compat]
-julia = "1.11"
+julia = "1.10"

--- a/ChunkCodecCore/src/ChunkCodecCore.jl
+++ b/ChunkCodecCore/src/ChunkCodecCore.jl
@@ -1,37 +1,39 @@
 module ChunkCodecCore
 
+using Compat: @compat
+
 export decode, encode
 
-public Codec
-public EncodeOptions
-public DecodeOptions
+@compat public Codec
+@compat public EncodeOptions
+@compat public DecodeOptions
 
-public DecodingError
-public DecodedSizeError
+@compat public DecodingError
+@compat public DecodedSizeError
 
-public decode_options
+@compat public decode_options
 
-public decoded_size_range
-public encode_bound
-public try_encode!
+@compat public decoded_size_range
+@compat public encode_bound
+@compat public try_encode!
 
-public try_find_decoded_size
-public try_decode!
+@compat public try_find_decoded_size
+@compat public try_decode!
 
-public check_in_range
-public check_contiguous
+@compat public check_in_range
+@compat public check_contiguous
 
-public can_concatenate
-public is_thread_safe
-public try_resize_decode!
+@compat public can_concatenate
+@compat public is_thread_safe
+@compat public try_resize_decode!
 
-public NoopCodec
-public NoopEncodeOptions
-public NoopDecodeOptions
+@compat public NoopCodec
+@compat public NoopEncodeOptions
+@compat public NoopDecodeOptions
 
-public ShuffleCodec
-public ShuffleEncodeOptions
-public ShuffleDecodeOptions
+@compat public ShuffleCodec
+@compat public ShuffleEncodeOptions
+@compat public ShuffleDecodeOptions
 
 include("types.jl")
 include("errors.jl")

--- a/ChunkCodecTests/Project.toml
+++ b/ChunkCodecTests/Project.toml
@@ -10,4 +10,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 ChunkCodecCore = "0.4"
 Test = "1"
-julia = "1.11"
+julia = "1.10"

--- a/ChunkCodecs/Project.toml
+++ b/ChunkCodecs/Project.toml
@@ -4,8 +4,8 @@ authors = ["nhz2 <nhz2@cornell.edu>"]
 version = "0.1.0"
 
 [deps]
-ChunkCodecLibBlosc = "c6a955be-ab7f-4fbb-b38f-caf93db6b928"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
+ChunkCodecLibBlosc = "c6a955be-ab7f-4fbb-b38f-caf93db6b928"
 ChunkCodecLibBzip2 = "2b723af9-f480-4e8d-a1e4-4a9f5a906122"
 ChunkCodecLibLz4 = "7e9cc85e-5614-42a3-ad86-b78f920b38a5"
 ChunkCodecLibSnappy = "eac87354-86d5-4a5b-ab5f-a6ee56b239b3"
@@ -13,20 +13,32 @@ ChunkCodecLibZlib = "4c0bbee4-addc-4d73-81a0-b6caacae83c8"
 ChunkCodecLibZstd = "55437552-ac27-4d47-9aa3-63184e8fd398"
 
 [compat]
-ChunkCodecLibBlosc = "0.1"
 ChunkCodecCore = "0.4"
+ChunkCodecLibBlosc = "0.1"
 ChunkCodecLibBzip2 = "0.1"
 ChunkCodecLibLz4 = "0.1"
 ChunkCodecLibSnappy = "0.1"
 ChunkCodecLibZlib = "0.1"
 ChunkCodecLibZstd = "0.1"
-julia = "1.11"
+julia = "1.10"
 
-[sources]
-ChunkCodecCore = {path = "../ChunkCodecCore"}
-ChunkCodecLibBlosc = {path = "../LibBlosc"}
-ChunkCodecLibBzip2 = {path = "../LibBzip2"}
-ChunkCodecLibLz4 = {path = "../LibLz4"}
-ChunkCodecLibSnappy = {path = "../LibSnappy"}
-ChunkCodecLibZlib = {path = "../LibZlib"}
-ChunkCodecLibZstd = {path = "../LibZstd"}
+[sources.ChunkCodecCore]
+path = "../ChunkCodecCore"
+
+[sources.ChunkCodecLibBlosc]
+path = "../LibBlosc"
+
+[sources.ChunkCodecLibBzip2]
+path = "../LibBzip2"
+
+[sources.ChunkCodecLibLz4]
+path = "../LibLz4"
+
+[sources.ChunkCodecLibSnappy]
+path = "../LibSnappy"
+
+[sources.ChunkCodecLibZlib]
+path = "../LibZlib"
+
+[sources.ChunkCodecLibZstd]
+path = "../LibZstd"

--- a/LibBlosc/Project.toml
+++ b/LibBlosc/Project.toml
@@ -6,8 +6,9 @@ version = "0.1.1"
 [deps]
 Blosc_jll = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
 Blosc_jll = "1"
 ChunkCodecCore = "0.4"
-julia = "1.11"
+julia = "1.10"

--- a/LibBlosc/src/ChunkCodecLibBlosc.jl
+++ b/LibBlosc/src/ChunkCodecLibBlosc.jl
@@ -1,5 +1,6 @@
 module ChunkCodecLibBlosc
 
+using Compat: @compat
 using Blosc_jll: libblosc
 
 using ChunkCodecCore:
@@ -22,7 +23,7 @@ export BloscCodec,
     BloscDecodeOptions,
     BloscDecodingError
 
-public is_compressor_valid, compcode, compname
+@compat public is_compressor_valid, compcode, compname
 
 # reexport ChunkCodecCore
 using ChunkCodecCore: ChunkCodecCore, encode, decode

--- a/LibBzip2/Project.toml
+++ b/LibBzip2/Project.toml
@@ -10,4 +10,4 @@ ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
 [compat]
 Bzip2_jll = "1"
 ChunkCodecCore = "0.4"
-julia = "1.11"
+julia = "1.10"

--- a/LibLz4/Project.toml
+++ b/LibLz4/Project.toml
@@ -10,4 +10,4 @@ Lz4_jll = "5ced341a-0733-55b8-9ab6-a4889d929147"
 [compat]
 ChunkCodecCore = "0.4"
 Lz4_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibSnappy/Project.toml
+++ b/LibSnappy/Project.toml
@@ -10,4 +10,4 @@ snappy_jll = "fe1e1685-f7be-5f59-ac9f-4ca204017dfd"
 [compat]
 ChunkCodecCore = "0.4"
 snappy_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibZlib/Project.toml
+++ b/LibZlib/Project.toml
@@ -10,4 +10,4 @@ Zlib_jll = "83775a58-1f1d-513f-b197-d71354ab007a"
 [compat]
 ChunkCodecCore = "0.4"
 Zlib_jll = "1"
-julia = "1.11"
+julia = "1.10"

--- a/LibZstd/Project.toml
+++ b/LibZstd/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.1"
 
 [deps]
 ChunkCodecCore = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 
 [compat]
 ChunkCodecCore = "0.4"
+Compat = "4.16.0"
 Zstd_jll = "1.5.6"
-julia = "1.11"
+julia = "1.10"

--- a/LibZstd/src/ChunkCodecLibZstd.jl
+++ b/LibZstd/src/ChunkCodecLibZstd.jl
@@ -1,5 +1,6 @@
 module ChunkCodecLibZstd
 
+using Compat: @compat
 using Zstd_jll: libzstd
 
 using ChunkCodecCore:
@@ -25,7 +26,7 @@ export ZstdCodec,
     ZstdDecodeOptions,
     ZstdDecodingError
 
-public ZSTD_minCLevel,
+@compat public ZSTD_minCLevel,
     ZSTD_maxCLevel,
     ZSTD_defaultCLevel,
     ZSTD_versionNumber,


### PR DESCRIPTION
use `@compat` from Compat.jl for the `public` keyword to make compatible with Julia 1.10 long term support (LTS) release
